### PR TITLE
Fix: Support BigQuery by adding cross-db utils

### DIFF
--- a/macros/cross-adapter-modeling/base/segment_web_page_views.sql
+++ b/macros/cross-adapter-modeling/base/segment_web_page_views.sql
@@ -32,9 +32,8 @@ renamed as (
         search as page_url_query,
         
         referrer,
-        ltrim({{ dbt_utils.get_url_host('referrer') }}, 'www.')::varchar 
-            as referrer_host,
-        
+        ltrim({{ dbt_utils.safe_cast(dbt_utils.get_url_host('referrer'), 'string') }}, 'www.') as referrer_host,
+
         context_campaign_source as utm_source,
         context_campaign_medium as utm_medium,
         context_campaign_name as utm_campaign,
@@ -44,10 +43,10 @@ renamed as (
         context_ip as ip,
         context_user_agent as user_agent,
         case
-            when context_user_agent ilike '%Android%' then 'Android'
+            when lower(context_user_agent) like '%android%' then 'Android'
             else replace(
-                split_part(split_part(context_user_agent,'(', 2), ' ', 1),
-                ';','') 
+                {{ dbt_utils.split_part(dbt_utils.split_part('context_user_agent', "'('", 2), "' '", 1) }},
+                ';', '')
         end as device
                         
     from source

--- a/macros/cross-adapter-modeling/base/segment_web_page_views.sql
+++ b/macros/cross-adapter-modeling/base/segment_web_page_views.sql
@@ -32,7 +32,7 @@ renamed as (
         search as page_url_query,
         
         referrer,
-        ltrim({{ dbt_utils.safe_cast(dbt_utils.get_url_host('referrer'), 'string') }}, 'www.') as referrer_host,
+        ltrim({{ dbt_utils.get_url_host('referrer') }}, 'www.') as referrer_host,
 
         context_campaign_source as utm_source,
         context_campaign_medium as utm_medium,

--- a/macros/cross-adapter-modeling/base/segment_web_page_views.sql
+++ b/macros/cross-adapter-modeling/base/segment_web_page_views.sql
@@ -62,7 +62,7 @@ final as (
             when device = 'Android' then 'Android'
             when device in ('iPad', 'iPod') then 'Tablet'
             when device in ('Windows', 'Macintosh', 'X11') then 'Desktop'
-            else 'uncategorized'
+            else 'Uncategorized'
         end as device_category
     from renamed
     

--- a/macros/cross-adapter-modeling/sessionization/segment_web_page_views__sessionized.sql
+++ b/macros/cross-adapter-modeling/sessionization/segment_web_page_views__sessionized.sql
@@ -82,7 +82,7 @@ diffed as (
 
     select
         *,
-        datediff(s, previous_tstamp, tstamp) as period_of_inactivity
+        {{ dbt_utils.datediff('previous_tstamp', 'tstamp', 'second') }} as period_of_inactivity
     from lagged
 
 ),

--- a/macros/cross-adapter-modeling/sessionization/segment_web_page_views__sessionized.sql
+++ b/macros/cross-adapter-modeling/sessionization/segment_web_page_views__sessionized.sql
@@ -31,7 +31,15 @@ with pageviews as (
     where anonymous_id in (
         select distinct anonymous_id 
         from {{ref('segment_web_page_views')}} 
-        where tstamp >= (select dateadd(hour, -{{var('segment_sessionization_trailing_window')}}, max(tstamp)) from {{this}})
+        where tstamp >= (
+          select {{
+            dbt_utils.safe_cast(
+              dbt_utils.dateadd(
+                'hour',
+                -var('segment_sessionization_trailing_window'),
+                'max(tstamp)'),
+              'timestamp') }}
+          from {{ this }})
         )
     {% endif %}
 

--- a/macros/cross-adapter-modeling/sessionization/segment_web_sessions.sql
+++ b/macros/cross-adapter-modeling/sessionization/segment_web_sessions.sql
@@ -29,12 +29,13 @@ with sessions as (
     
     {% if is_incremental() %}
     where session_start_tstamp > (
-        select 
-            dateadd(
-                hour, 
-                -{{var('segment_sessionization_trailing_window')}}, 
-                max(session_start_tstamp)
-                ) 
+        select {{
+          dbt_utils.safe_cast(
+            dbt_utils.dateadd(
+              'hour',
+              -var('segment_sessionization_trailing_window'),
+              'max(session_start_tstamp)'),
+          'timestamp') }}
         from {{this}})
     {% endif %}
 

--- a/macros/cross-adapter-modeling/sessionization/segment_web_sessions__initial.sql
+++ b/macros/cross-adapter-modeling/sessionization/segment_web_sessions__initial.sql
@@ -84,8 +84,8 @@ diffs as (
     
         *,
         
-        datediff(s, session_start_tstamp, session_end_tstamp) as duration_in_s
-    
+        {{ dbt_utils.datediff('session_start_tstamp', 'session_end_tstamp', 'second') }} as duration_in_s
+
     from agg
 
 ),


### PR DESCRIPTION
I've replaced some of the Redshift-specific commands in this package with macros from `dbt-utils` that should work in multiple databases.

I don't have the ability to test this in Snowflake, but I'm able to run it successfully in BigQuery with these changes.