### PR TITLE
Use dbt_utils version of dateadd instead of Redshift version

### DIFF
--- a/macros/cross-adapter-modeling/sessionization/segment_web_sessions.sql
+++ b/macros/cross-adapter-modeling/sessionization/segment_web_sessions.sql
@@ -16,12 +16,13 @@
     
 {% set sessionization_cutoff = "
 (
-    select 
-        dateadd(
-            hour, 
-            -{{var('segment_sessionization_trailing_window')}}, 
-            max(session_start_tstamp)
-            ) 
+    select {{
+        dbt_utils.safe_cast(
+            dbt_utils.dateadd(
+                'hour',
+                -var('segment_sessionization_trailing_window'),
+                'max(session_start_tstamp)'),
+            'timestamp') }}
     from {{this}}
 )    
 " %}


### PR DESCRIPTION
In PR #12, I accidentally undid some of @joshtemple's great work in PR #8, which introduced BigQuery compatibility.

In the PR, I reverted to the Redshift-native version of `dateadd` instead of the `dbt_utils` version. This PR re-implements the `dbt_utils` version.

@joshtemple - first of all, my bad! Also, are you able to test this version for us?

I've tested this in Redshift and it works.