### PR TITLE
small changes to enable configurable session inactivity

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -14,10 +14,15 @@ clean-targets:
 
 models:
     vars:
-        #location of raw data table
+        # location of raw data table
         segment_page_views_table: 
         
         # number of trailing hours to re-sessionize for. 
         # events can come in late and we want to still be able to incorporate 
         # them into the definition of a session without needing a full refresh.
         segment_sessionization_trailing_window: 3 
+        
+        # sessionization inactivity cutoff: of there is a gap in page view times
+        # that exceeds this number of seconds, the subsequent page view will
+        # start a new session.
+        segment_inactivity_cutoff: 30 * 60

--- a/macros/cross-adapter-modeling/base/segment_web_page_views.sql
+++ b/macros/cross-adapter-modeling/base/segment_web_page_views.sql
@@ -32,7 +32,7 @@ renamed as (
         search as page_url_query,
         
         referrer,
-        ltrim({{ dbt_utils.get_url_host('referrer') }}, 'www.') as referrer_host,
+        {{ dbt_utils.get_url_host('referrer') }} as referrer_host,
 
         context_campaign_source as utm_source,
         context_campaign_medium as utm_medium,

--- a/macros/cross-adapter-modeling/sessionization/segment_web_page_views__sessionized.sql
+++ b/macros/cross-adapter-modeling/sessionization/segment_web_page_views__sessionized.sql
@@ -104,7 +104,7 @@ new_sessions as (
     select 
         *,
         case 
-            when period_of_inactivity <= 30 * 60 then 0
+            when period_of_inactivity <= {{var('segment_inactivity_cutoff')}} then 0
             else 1
         end as new_session
     from diffed


### PR DESCRIPTION
Pretty small changes, primarily targeted at allowing users to configure their inactivity window. The only other fix that I snuck in there was that our `ltrim()` wasn't actually doing what we wanted--it was removing leading `w` characters from the actual url as well, which is kind of a problem for anyone who legitimately has a `w` in their url.