### PR TITLE
Add variable to pass extra columns through the package

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -26,3 +26,8 @@ models:
         # that exceeds this number of seconds, the subsequent page view will
         # start a new session.
         segment_inactivity_cutoff: 30 * 60
+        
+        # if there are extra columns that are important to pass through, define
+        # them here. Extremely useful when you have unioned together multiple
+        # segment sources and want to pass through a column indivating the source
+        segment_pass_through_columns: []

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -27,7 +27,9 @@ models:
         # start a new session.
         segment_inactivity_cutoff: 30 * 60
         
-        # if there are extra columns that are important to pass through, define
-        # them here. Extremely useful when you have unioned together multiple
-        # segment sources and want to pass through a column indivating the source
+        # If there are extra columns you wish to pass through this package,
+        # define them here. Columns will be included in the `segment_web_sessions`
+        # model as `first_<column>` and `last_<column>`. Extremely useful when
+        # using this package on top of unioned Segment sources, as you can then
+        # pass through a column indicating which source the data is from.
         segment_pass_through_columns: []

--- a/macros/cross-adapter-modeling/base/segment_web_page_views.sql
+++ b/macros/cross-adapter-modeling/base/segment_web_page_views.sql
@@ -48,6 +48,12 @@ renamed as (
                 {{ dbt_utils.split_part(dbt_utils.split_part('context_user_agent', "'('", 2), "' '", 1) }},
                 ';', '')
         end as device
+        
+        {% if var('segment_pass_through_columns') != [] %}
+        ,
+        {{ var('segment_pass_through_columns') | join (", ")}}
+        
+        {% endif %}
                         
     from source
 

--- a/macros/cross-adapter-modeling/sessionization/segment_web_sessions__initial.sql
+++ b/macros/cross-adapter-modeling/sessionization/segment_web_sessions__initial.sql
@@ -45,6 +45,11 @@
     'page_url_path' : 'last_page_url_path',
     'page_url_query' : 'last_page_url_query'
     } %}
+    
+{% for col in var('segment_pass_through_columns') %}
+    {% do first_values.update({col: 'first_' ~ col}) %}
+    {% do last_values.update({col: 'last_' ~ col}) %}
+{% endfor %}
 
 with pageviews as (
 


### PR DESCRIPTION
I've implemented this in one of my projects and it works as expected!

Example usage:
```yaml
models:
  segment:
    schema: staging
    vars:
      segment_pass_through_columns:
        - 'source'
```

Then at the other end I have:
```
segment_web_sessions.first_source
segment_web_sessions.last_source
```
(both `first_` and `last_` are found for any pass-through columns)