### PR TITLE
Fix nested Jinja for DBT 0.15

### DIFF
--- a/macros/cross-adapter-modeling/sessionization/segment_web_sessions.sql
+++ b/macros/cross-adapter-modeling/sessionization/segment_web_sessions.sql
@@ -13,34 +13,21 @@
     sort = 'session_start_tstamp',
     dist = 'session_id'
     )}}
-    
-{% set sessionization_cutoff = "
-(
-    select {{
-        dbt_utils.safe_cast(
-            dbt_utils.dateadd(
-                'hour',
-                -var('segment_sessionization_trailing_window'),
-                'max(session_start_tstamp)'),
-            'timestamp') }}
-    from {{this}}
-)    
-" %}
 
-{# 
-Window functions are challenging to make incremental. This approach grabs 
+{#
+Window functions are challenging to make incremental. This approach grabs
 existing values from the existing table and then adds the value of session_number
-on top of that seed. During development, this decreased the model runtime 
-by 25x on 2 years of data (from 600 to 25 seconds), so even though the code is 
+on top of that seed. During development, this decreased the model runtime
+by 25x on 2 years of data (from 600 to 25 seconds), so even though the code is
 more complicated, the performance tradeoff is worth it.
 #}
 
 with sessions as (
 
     select * from {{ref('segment_web_sessions__stitched')}}
-    
+
     {% if is_incremental() %}
-    where session_start_tstamp > {{sessionization_cutoff}}
+    where session_start_tstamp > ({{segment.sessionization_cutoff()}})
     {% endif %}
 
 ),
@@ -49,13 +36,13 @@ with sessions as (
 
 agg as (
 
-    select 
-        blended_user_id, 
+    select
+        blended_user_id,
         count(*) as starting_session_number
     from {{this}}
-    
+
     -- only include sessions that are not going to be resessionized in this run
-    where session_start_tstamp <= {{sessionization_cutoff}}
+    where session_start_tstamp <= ({{segment.sessionization_cutoff()}})
 
     group by 1
 
@@ -65,23 +52,23 @@ agg as (
 
 windowed as (
 
-    select 
+    select
 
         *,
 
         row_number() over (
-            partition by blended_user_id 
+            partition by blended_user_id
             order by sessions.session_start_tstamp
-            ) 
+            )
             {% if is_incremental() %}+ agg.starting_session_number {% endif %}
             as session_number
 
     from sessions
-    
+
     {% if is_incremental() %}
-    left join agg using (blended_user_id) 
+    left join agg using (blended_user_id)
     {% endif %}
-    
+
 
 )
 

--- a/macros/cross-adapter-modeling/sessionization/sessionization_cutoff.sql
+++ b/macros/cross-adapter-modeling/sessionization/sessionization_cutoff.sql
@@ -1,0 +1,12 @@
+{% macro sessionization_cutoff() %}
+
+    select {{
+        dbt_utils.safe_cast(
+            dbt_utils.dateadd(
+                'hour',
+                -var('segment_sessionization_trailing_window'),
+                'max(session_start_tstamp)'),
+            'timestamp') }}
+    from {{this}}
+
+{% endmacro %}


### PR DESCRIPTION
With the changes in DBT 0.15, the way that the sessionization cutoff is generated is failing. This moves nested Jina to a new macro, `sessionization_cutoff`. This is the only functional change in this PR - there is also a bit of trailing whitespace cleanup and deleting `macros/.gitkeep` which isn't necessary.