### PR TITLE
Fix null session numbers

### DIFF
--- a/macros/cross-adapter-modeling/sessionization/segment_web_sessions.sql
+++ b/macros/cross-adapter-modeling/sessionization/segment_web_sessions.sql
@@ -72,7 +72,7 @@ windowed as (
             partition by blended_user_id
             order by sessions.session_start_tstamp
             )
-            {% if is_incremental() %}+ agg.starting_session_number {% endif %}
+            {% if is_incremental() %}+ coalesce(agg.starting_session_number, 0) {% endif %}
             as session_number
 
     from sessions


### PR DESCRIPTION
Opening in favor of #32 (since I rebased)

> @invinceyble
> The left join with agg could mean that the whole expression is null, since any number + null is null.
> This PR fixes that so session_number will never be null.
