### PR TITLE
Update README - formatting fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ out bad records, do this in an upstream model.
 
 4. Optionally configure extra parameters by adding them to your own `dbt_project.yml` file – see [dbt_project.yml](dbt_project.yml)
 for more details:
-```yaml
+
+```YAML
 # dbt_project.yml
 config-version: 2
 


### PR DESCRIPTION
## Description & motivation

README on [dbt hub](https://hub.getdbt.com/fishtown-analytics/segment/latest/) is not displayed properly for the second code snippet. I have unified code fences formatting between two snippets to make it work

## Checklist
- [ ] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
