### PR TITLE
Add deduplication of source page views

### DIFF
--- a/models/base/docs.md
+++ b/models/base/docs.md
@@ -3,6 +3,6 @@
 {% docs segment_web_page_views %}
 
 This is a base model for Segment's web page views table. It does some straightforward renaming and parsing of Segment raw data in this table.
-If there are multiple entries in the source table for one page view id deduplication is done to keep the row with the earliest `received_at` timestamp.
+If a page view id has multiple entries in the source table then deduplication is done to keep the row with the earliest `received_at` timestamp.
 
 {% enddocs %}

--- a/models/base/docs.md
+++ b/models/base/docs.md
@@ -3,5 +3,6 @@
 {% docs segment_web_page_views %}
 
 This is a base model for Segment's web page views table. It does some straightforward renaming and parsing of Segment raw data in this table.
+If there are multiple entries in the source table for one page view id deduplication is done to keep the row with the earliest `received_at` timestamp.
 
 {% enddocs %}

--- a/models/base/segment_web_page_views.sql
+++ b/models/base/segment_web_page_views.sql
@@ -4,6 +4,24 @@ with source as (
 
 ),
 
+row_numbering as (
+
+    select
+        *,
+        row_number() over (partition by id order by received_at asc) as row_num
+    from source
+
+),
+
+deduped as (
+
+    select
+        *
+    from row_numbering
+    where row_num = 1
+
+),
+
 renamed as (
 
     select
@@ -50,7 +68,7 @@ renamed as (
 
         {% endif %}
 
-    from source
+    from deduped
 
 ),
 


### PR DESCRIPTION
## Description & motivation
Segment's source table in your warehouse for page views may contain multiple rows for a `page_view_id`. I'm seeing rows with the same id and `received_at` timestamps that can differ by up to a week. This was causing two issues:
- Unique tests on the primary keys for `segment_web_page_views` and `segment_web_page_views_sessionized` would fail
- Subsequent runs of the package would fail as a merge from an incremental task would get an error. This would cause subsequent tables to not update (running `--full-refresh` would allow an update).

Adding deduping CTEs fixes these problems. I'm using BigQuery.

## Checklist
- [x] I have verified that these changes work locally
- [N/A] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
