### PR TITLE
Ensure proper incremental filtering + test for session_number

### DIFF
--- a/macros/generate_sessionization_incremental_filter.sql
+++ b/macros/generate_sessionization_incremental_filter.sql
@@ -1,10 +1,10 @@
-{% macro generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp) %}
-    {{ return(adapter.dispatch('generate_sessionization_incremental_filter', 'segment') (merge_target, filter_tstamp, max_tstamp)) }}
+{% macro generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp, operator) %}
+    {{ return(adapter.dispatch('generate_sessionization_incremental_filter', 'segment') (merge_target, filter_tstamp, max_tstamp, operator)) }}
 {% endmacro %}
 
 
-{% macro default__generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp) %}
-    where {{ filter_tstamp }} >= (
+{% macro default__generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp, operator) %}
+    where {{ filter_tstamp }} {{ operator }} (
         select
             {{ dbt_utils.dateadd(
                 'hour',
@@ -15,8 +15,8 @@
     )
 {%- endmacro -%}
 
-{% macro bigquery__generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp) %}
-    where {{ filter_tstamp }} >= (
+{% macro bigquery__generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp, operator) %}
+    where {{ filter_tstamp }} {{ operator }} (
         select 
             timestamp_sub(
                 max({{ max_tstamp }}), 
@@ -26,8 +26,8 @@
     )
 {%- endmacro -%}
 
-{% macro postgres__generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp) %}
-    where cast({{ filter_tstamp }} as timestamp) >= (
+{% macro postgres__generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp, operator) %}
+    where cast({{ filter_tstamp }} as timestamp) {{ operator }} (
         select
             {{ dbt_utils.dateadd(
                 'hour',

--- a/models/sessionization/schema.yml
+++ b/models/sessionization/schema.yml
@@ -42,3 +42,7 @@ models:
         tests:
           - unique
           - not_null
+      - name: cast(blended_user_id as string) || cast(session_number as string)
+        description: 'Make sure session_number is not repeated for any given user'
+        tests:
+          - unique

--- a/models/sessionization/schema.yml
+++ b/models/sessionization/schema.yml
@@ -42,7 +42,3 @@ models:
         tests:
           - unique
           - not_null
-      - name: cast(blended_user_id as string) || cast(session_number as string)
-        description: 'Make sure session_number is not repeated for any given user'
-        tests:
-          - unique

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -25,7 +25,7 @@ with pageviews as (
         select distinct anonymous_id
         from {{ref('segment_web_page_views')}}
         {{
-            generate_sessionization_incremental_filter( this, 'tstamp', 'tstamp' )
+            generate_sessionization_incremental_filter( this, 'tstamp', 'tstamp', '>' )
         }}
     )
     {% endif %}

--- a/models/sessionization/segment_web_sessions.sql
+++ b/models/sessionization/segment_web_sessions.sql
@@ -21,7 +21,7 @@ with sessions as (
 
     {% if is_incremental() %}
     {{
-        generate_sessionization_incremental_filter( this, 'session_start_tstamp', 'session_start_tstamp' )
+        generate_sessionization_incremental_filter( this, 'session_start_tstamp', 'session_start_tstamp', '>' )
     }}
     {% endif %}
 
@@ -38,7 +38,7 @@ agg as (
 
     -- only include sessions that are not going to be resessionized in this run
     {{
-        generate_sessionization_incremental_filter( this, 'session_start_tstamp', 'session_start_tstamp' )
+        generate_sessionization_incremental_filter( this, 'session_start_tstamp', 'session_start_tstamp', '<=' )
     }}
 
     group by 1

--- a/models/sessionization/segment_web_sessions__initial.sql
+++ b/models/sessionization/segment_web_sessions__initial.sql
@@ -50,7 +50,7 @@ with pageviews_sessionized as (
 
     {% if is_incremental() %}
     {{
-        generate_sessionization_incremental_filter( this, 'tstamp', 'session_start_tstamp' )
+        generate_sessionization_incremental_filter( this, 'tstamp', 'session_start_tstamp', '>' )
     }}
     {% endif %}
 

--- a/models/sessionization/segment_web_sessions__stitched.sql
+++ b/models/sessionization/segment_web_sessions__stitched.sql
@@ -13,7 +13,7 @@ with sessions as (
 
     {% if is_incremental() %}
     {{
-        generate_sessionization_incremental_filter( this, 'session_start_tstamp', 'session_start_tstamp' )
+        generate_sessionization_incremental_filter( this, 'session_start_tstamp', 'session_start_tstamp', '>' )
     }}
     {% endif %}
 


### PR DESCRIPTION
## Description & motivation
This addresses #80 -- made a modification to the new macro to take a comparison operator since we need to filter before the `segment_sessionization_trailing_window` and after in `segment_web_sessions`. 

Also added a test to make sure session_number does not repeat for users.

cc @joellabes 

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
