### PR TITLE
Removes dbt_utils scope for macros now in Core. Bumps dbt_utils version.

### DIFF
--- a/macros/generate_sessionization_incremental_filter.sql
+++ b/macros/generate_sessionization_incremental_filter.sql
@@ -6,7 +6,7 @@
 {% macro default__generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp, operator) %}
     where {{ filter_tstamp }} {{ operator }} (
         select
-            {{ dbt_utils.dateadd(
+            {{ dateadd(
                 'hour',
                 -var('segment_sessionization_trailing_window'),
                 'max(' ~ max_tstamp ~ ')'
@@ -29,7 +29,7 @@
 {% macro postgres__generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp, operator) %}
     where cast({{ filter_tstamp }} as timestamp) {{ operator }} (
         select
-            {{ dbt_utils.dateadd(
+            {{ dateadd(
                 'hour',
                 -var('segment_sessionization_trailing_window'),
                 'max(' ~ max_tstamp ~ ')'

--- a/models/base/segment_web_page_views.sql
+++ b/models/base/segment_web_page_views.sql
@@ -58,7 +58,7 @@ renamed as (
         case
             when lower(context_user_agent) like '%android%' then 'Android'
             else replace(
-                {{ dbt_utils.split_part(dbt_utils.split_part('context_user_agent', "'('", 2), "' '", 1) }},
+                {{ split_part(split_part('context_user_agent', "'('", 2), "' '", 1) }},
                 ';', '')
         end as device
 

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -77,7 +77,7 @@ diffed as (
 
     select
         *,
-        {{ dbt_utils.datediff('previous_tstamp', 'tstamp', 'second') }} as period_of_inactivity
+        {{ datediff('previous_tstamp', 'tstamp', 'second') }} as period_of_inactivity
     from lagged
 
 ),

--- a/models/sessionization/segment_web_sessions__initial.sql
+++ b/models/sessionization/segment_web_sessions__initial.sql
@@ -90,7 +90,7 @@ diffs as (
 
         *,
 
-        {{ dbt_utils.datediff('session_start_tstamp', 'session_end_tstamp', 'second') }} as duration_in_s
+        {{ datediff('session_start_tstamp', 'session_end_tstamp', 'second') }} as duration_in_s
 
     from agg
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: dbt-labs/dbt_utils
-   version: [">=0.8.0", "<0.9.0"]
+   version: [">=0.8.0", "<0.10.0"]


### PR DESCRIPTION
Allows this package to be installed on projects with newer versions of dbt_utils. Now relies on the dbt-core versions of `dateadd`, `split_part`, and `datediff` rather than dbt_utils. Allows dbt_utils to move up to `0.10.0`.