### PR TITLE
Add v1 compatibility and deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> ⛔🏚️ This package is no longer developed or maintained by dbt Labs. If you're interested in forking/adopting it, reach out in #package-ecosystem on dbt Slack.
+
 # dbt-segment
 This [dbt package](https://docs.getdbt.com/docs/package-management):
 * Performs "user stitching" to tie all events associated with a cookie to the same user_id

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 name: 'segment'
 version: '0.7.0'
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.3.0", "<2.0.0"]
 config-version: 2
 
 model-paths: ["models"]

--- a/macros/generate_sessionization_incremental_filter.sql
+++ b/macros/generate_sessionization_incremental_filter.sql
@@ -6,7 +6,7 @@
 {% macro default__generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp, operator) %}
     where {{ filter_tstamp }} {{ operator }} (
         select
-            {{ dbt_utils.dateadd(
+            {{ dbt.dateadd(
                 'hour',
                 -var('segment_sessionization_trailing_window'),
                 'max(' ~ max_tstamp ~ ')'
@@ -29,7 +29,7 @@
 {% macro postgres__generate_sessionization_incremental_filter(merge_target, filter_tstamp, max_tstamp, operator) %}
     where cast({{ filter_tstamp }} as timestamp) {{ operator }} (
         select
-            {{ dbt_utils.dateadd(
+            {{ dbt.dateadd(
                 'hour',
                 -var('segment_sessionization_trailing_window'),
                 'max(' ~ max_tstamp ~ ')'

--- a/models/base/segment_web_page_views.sql
+++ b/models/base/segment_web_page_views.sql
@@ -58,7 +58,7 @@ renamed as (
         case
             when lower(context_user_agent) like '%android%' then 'Android'
             else replace(
-                {{ dbt_utils.split_part(dbt_utils.split_part('context_user_agent', "'('", 2), "' '", 1) }},
+                {{ dbt.split_part(dbt.split_part('context_user_agent', "'('", 2), "' '", 1) }},
                 ';', '')
         end as device
 

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -77,7 +77,7 @@ diffed as (
 
     select
         *,
-        {{ dbt_utils.datediff('previous_tstamp', 'tstamp', 'second') }} as period_of_inactivity
+        {{ dbt.datediff('previous_tstamp', 'tstamp', 'second') }} as period_of_inactivity
     from lagged
 
 ),
@@ -127,7 +127,7 @@ session_ids as (
 
         {{dbt_utils.star(ref('segment_web_page_views'))}},
         page_view_number,
-        {{dbt_utils.surrogate_key(['anonymous_id', 'session_number'])}} as session_id
+        {{dbt_utils.generate_surrogate_key(['anonymous_id', 'session_number'])}} as session_id
 
     from session_numbers
 

--- a/models/sessionization/segment_web_sessions__initial.sql
+++ b/models/sessionization/segment_web_sessions__initial.sql
@@ -90,7 +90,7 @@ diffs as (
 
         *,
 
-        {{ dbt_utils.datediff('session_start_tstamp', 'session_end_tstamp', 'second') }} as duration_in_s
+        {{ dbt.datediff('session_start_tstamp', 'session_end_tstamp', 'second') }} as duration_in_s
 
     from agg
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: dbt-labs/dbt_utils
-   version: [">=1.0.0", "<2.0.0"]
+   version: [">=1.0.0-rc1", "<2.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: dbt-labs/dbt_utils
-   version: [">=0.8.0", "<0.9.0"]
+   version: [">=1.0.0", "<2.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: dbt-labs/dbt_utils
-   version: [">=1.0.0-rc1", "<2.0.0"]
+   version: [">=1.0.0", "<2.0.0"]


### PR DESCRIPTION
## Description & motivation
This will be the final release of this package. It creates compatibility with dbt utils v1 for anyone who needs that, so that it will keep running for as long as possible.



## Checklist
- [ ] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
