### PR TITLE
Change `min_by` to `min`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,37 @@
+# babylist/dbt_segment v0.2.0
+
+## Improvements
+
+- Remove expensive deduplication of source page views, which is already handled upstream in our dbt models
+- Add uniquifying element to page view sessionization to account for subsetting of source page view model
+
+# babylist/dbt_segment v0.1.0
+
+This release restarts versioning at v0.8.1 of the upstream repo, which is what we're using as of April 2024.
+
 # segment v0.8.1
+
 ## Fixes
+
 - Fix duplication of sources in incremental materializations ([#80](https://github.com/dbt-labs/segment/issues/80), [#81](https://github.com/dbt-labs/segment/pull/81))
 
-Contributors: 
+Contributors:
+
 - [rjh336](https://github.com/rjh336) (#81)
 
 # segment v0.8.0
+
 ## New Features
+
 - Postgres Support ([#69](https://github.com/dbt-labs/segment/issues/69), [#70](https://github.com/dbt-labs/segment/pull/70))
 
 ## Improvements
+
 - Significantly improved BigQuery performance ([#72](https://github.com/dbt-labs/segment/issues/72), [#73](https://github.com/dbt-labs/segment/pull/73))
 - Deduplication of source page views ([#76](https://github.com/dbt-labs/segment/pull/76))
 
-Contributors: 
+Contributors:
+
 - [shippy](https://github.com/shippy) (#70)
 - [rjh336](https://github.com/rjh336) (#73)
 - [MarkMacArdle](https://github.com/MarkMacArdle) (#76)
@@ -23,6 +41,7 @@ Contributors:
 This release supports any version (minor and patch) of v1, which means far less need for compatibility releases in the future.
 
 ## Under the hood
+
 - Change `require-dbt-version` to `[">=1.0.0", "<2.0.0"]`
 - Bump dbt-utils dependency
 - Replace `source-paths` and `data-paths` with `model-paths` and `seed-paths` respectively
@@ -30,4 +49,5 @@ This release supports any version (minor and patch) of v1, which means far less 
 - Replace `dbt_modules` with `dbt_packages` in `clean-targets`
 
 # segment v0.6.1
+
 🚨 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). Projects using this version with `dbt-core` v1.0.x can expect to see a deprecation warning. This will be resolved in the next minor release.

--- a/README.md
+++ b/README.md
@@ -1,55 +1,63 @@
-# dbt-segment
+# dbt_segment
+
 This [dbt package](https://docs.getdbt.com/docs/package-management):
+
 * Performs "user stitching" to tie all events associated with a cookie to the same user_id
 * Transforms pageviews into sessions ("sessionization")
 
+This has been forked from the original upstream repo by dbt Labs in order to apply optimizations for Babylist's dbt project.
 
 ## Installation instructions
+
 New to dbt packages? Read more about them [here](https://docs.getdbt.com/docs/building-a-dbt-project/package-management/).
+
 1. Include this package in your `packages.yml` — check [here](https://hub.getdbt.com/dbt-labs/segment/latest/) for the latest version number.
 2. Run `dbt deps`
 3. Include the following in your `dbt_project.yml` directly within your `vars:` block (making sure to handle indenting appropriately). **Update the value to point to your segment page views table**.
 
-```YAML
-# dbt_project.yml
-config-version: 2
-...
+    ```YAML
+    # dbt_project.yml
+    config-version: 2
+    ...
 
-vars:
-  segment:
-    segment_page_views_table: "{{ source('segment', 'pages') }}"
+    vars:
+      segment:
+        segment_page_views_table: "{{ source('segment', 'pages') }}"
 
-```
-This package assumes that your data is in a structure similar to the test
-file included in [example_segment_pages](integration_tests/seeds/example_segment_pages.csv).
-You may have to do some pre-processing in an upstream model to get it into this shape.
-Similarly, if you need to union multiple sources, de-duplicate records, or filter
-out bad records, do this in an upstream model.
+    ```
+
+    This package assumes that your data is in a structure similar to the test
+    file included in [example_segment_pages](integration_tests/seeds/example_segment_pages.csv).
+    You may have to do some pre-processing in an upstream model to get it into this shape.
+    Similarly, if you need to union multiple sources, de-duplicate records, or filter
+    out bad records, do this in an upstream model.
 
 4. Optionally configure extra parameters by adding them to your own `dbt_project.yml` file – see [dbt_project.yml](dbt_project.yml)
 for more details:
 
-```YAML
-# dbt_project.yml
-config-version: 2
+    ```YAML
+    # dbt_project.yml
+    config-version: 2
 
-...
+    ...
 
-vars:
-  segment:
-    segment_page_views_table: "{{ source('segment', 'pages') }}"
-    segment_sessionization_trailing_window: 3
-    segment_inactivity_cutoff: 30 * 60
-    segment_pass_through_columns: []
-    segment_bigquery_partition_granularity: 'day' # BigQuery only: partition granularity for `partition_by` config
+    vars:
+      segment:
+        segment_page_views_table: "{{ source('segment', 'pages') }}"
+        segment_sessionization_trailing_window: 3
+        segment_inactivity_cutoff: 30 * 60
+        segment_pass_through_columns: []
+        segment_bigquery_partition_granularity: 'day' # BigQuery only: partition granularity for `partition_by` config
 
-```
-5. Execute `dbt seed` -- this project includes a CSV that must be seeded for it
-the package to run successfully.
+    ```
+
+5. Execute `dbt seed` -- this project includes a CSV that must be seeded for the package to run successfully.
 6. Execute `dbt run` – the Segment models will get built as part of your run!
 
 ## Database support
+
 This package has been tested on Redshift, Snowflake, BigQuery, and Postgres.
 
 ### Contributing
+
 Additional contributions to this repo are very welcome! Check out [this post](https://discourse.getdbt.com/t/contributing-to-a-dbt-package/657) on the best workflow for contributing to a package. All PRs should only include functionality that is contained within all Segment deployments; no implementation-specific details should be included.

--- a/models/base/segment_web_page_views.sql
+++ b/models/base/segment_web_page_views.sql
@@ -4,24 +4,6 @@ with source as (
 
 ),
 
-row_numbering as (
-
-    select
-        *,
-        row_number() over (partition by id order by received_at asc) as row_num
-    from source
-
-),
-
-deduped as (
-
-    select
-        *
-    from row_numbering
-    where row_num = 1
-
-),
-
 renamed as (
 
     select
@@ -33,6 +15,7 @@ renamed as (
         received_at as received_at_tstamp,
         sent_at as sent_at_tstamp,
         timestamp as tstamp,
+        event_date,
 
         url as page_url,
         {{ dbt_utils.get_url_host('url') }} as page_url_host,
@@ -68,7 +51,7 @@ renamed as (
 
         {% endif %}
 
-    from deduped
+    from source
 
 ),
 

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -169,7 +169,7 @@ consolidated_session as (
         --this line handles new events that are part of an existing session - instead of assigning a brand new
         --session ID, see if there's an existing session ID from other events in the same session, and use that
         coalesce(
-            min_by(existing_session_id, tstamp) over (partition by anonymous_id, session_start_tstamp), --existing ID across the session
+            min(existing_session_id) over (partition by anonymous_id, session_start_tstamp), --existing ID across the session
             session_id --fall back to new session_id
         ) as session_id
     from session_ids

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -172,4 +172,4 @@ consolidated_session as (
 
 )
 
-select * from session_ids
+select * from consolidated_session

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -168,7 +168,7 @@ consolidated_session as (
         --this line handles new events that are part of an existing session - instead of assigning a brand new
         --session ID, see if there's an existing session ID from other events in the same session, and use that
         coalesce(
-            min_by(existing_session_id, tstamp) over (partition by session_id), --existing ID across the session
+            min_by(existing_session_id, tstamp) over (partition by anonymous_id, session_id), --existing ID across the session
             session_id --fall back to new session_id
         ) as session_id
     from session_ids

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -140,16 +140,35 @@ session_starts as (
 
 session_ids as (
 
-    --This CTE assigns a globally unique session id based on the combination of
-    --`anonymous_id` and `session_number`.
+    --This CTE assigns a unique session id based on the combination of
+    --`anonymous_id`, `session_start_tstamp`, and `session_number`.
+    --including `session_start_tstamp` helps us uniquify since we no longer
+    --include the full lifetime of events in `segment_web_page_views`.
 
     select
 
-        {{dbt_utils.star(ref('segment_web_page_views'))}},
-        page_view_number,
-        {{dbt_utils.surrogate_key(['anonymous_id', 'session_start_tstamp', 'session_number'])}} as session_id
+        {{dbt_utils.star(from=ref('segment_web_page_views'), relation_alias='session_starts')}},
+        session_starts.page_view_number,
+        --if an event has previously been sessionized, keep the existing session ID
+        {% if is_incremental() %}sessionized.session_id{% else %}null::string{% endif %} as existing_session_id,
+        {{dbt_utils.surrogate_key(['session_starts.anonymous_id', 'session_starts.session_start_tstamp', 'session_starts.session_number'])}} as session_id
 
     from session_starts
+    {% if is_incremental() %}
+    left join {{ this }} as sessionized
+        on session_starts.page_view_id = sessionized.page_view_id
+    {% endif %}
+
+),
+
+consolidated_session as (
+
+    select
+        * exclude (existing_session_id, session_id),
+        --this line handles new events that are part of an existing session - instead of assigning a brand new
+        --session ID, see if there's an existing session ID from other events in the same session, and use that
+        min_by(coalesce(existing_session_id, session_id), tstamp) over (partition by session_id) as session_id
+    from session_ids
 
 )
 

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -169,7 +169,7 @@ consolidated_session as (
         --this line handles new events that are part of an existing session - instead of assigning a brand new
         --session ID, see if there's an existing session ID from other events in the same session, and use that
         coalesce(
-            min(existing_session_id) over (partition by anonymous_id, session_start_tstamp), --existing ID across the session
+            min_by(existing_session_id, tstamp) over (partition by anonymous_id, session_start_tstamp), --existing ID across the session
             session_id --fall back to new session_id
         ) as session_id
     from session_ids

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -167,7 +167,10 @@ consolidated_session as (
         * exclude (existing_session_id, session_id),
         --this line handles new events that are part of an existing session - instead of assigning a brand new
         --session ID, see if there's an existing session ID from other events in the same session, and use that
-        min_by(coalesce(existing_session_id, session_id), tstamp) over (partition by session_id) as session_id
+        coalesce(
+            min_by(existing_session_id, tstamp) over (partition by session_id), --existing ID across the session
+            session_id --fall back to new session_id
+        ) as session_id
     from session_ids
 
 )


### PR DESCRIPTION
There are edge cases where `min_by` only returns `null` records, therefore defaulting to the new session ID when an existing one is available.

We're partitioning the data well enough to where `min` should accomplish the same thing without this side effect.